### PR TITLE
version 1.3.10 + RELEASING.md cleanup

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,5 +34,4 @@ Publishing is manual, following the same pattern as [`slack-edge`](https://githu
 
 ## Notes
 
-- Tags through `1.3.9` use bare semver (no prefix). The `v` prefix is the going-forward convention starting with the next release, matching `slack-edge`.
 - If you'd rather not pass `--tag-version-prefix=v` every time, set it once globally: `npm config set tag-version-prefix v`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-cloudflare-workers",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-cloudflare-workers",
-      "version": "1.3.9",
+      "version": "1.3.10",
       "license": "MIT",
       "dependencies": {
         "@cloudflare/workers-types": "^4.20260130.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-cloudflare-workers",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "Slack app development framework for Cloudflare Workers",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary
- Bumps `package.json` / `package-lock.json` to **1.3.10** — picks up the fixes from #25 (inline sourcemap sources, `files` allowlist, `prepublishOnly`).
- Drops the historical "tags through 1.3.9 use bare semver" note from `RELEASING.md` — not needed in the doc going forward.

## Publish
Once merged, cut the release from `main` per `RELEASING.md`:
```sh
git checkout main && git pull
git tag v1.3.10
git push origin v1.3.10
npm publish
gh release create v1.3.10 --title v1.3.10 --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)