### PR TITLE
Add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/simple-app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      simple-app-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/examples/oauth-app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      oauth-app-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly update streams for the root npm package, both example apps (`examples/simple-app`, `examples/oauth-app`), and GitHub Actions.
- Groups dev dependencies and example-app dependencies to reduce PR noise.

## Test plan
- [ ] Merge and confirm Dependabot picks up the config (Insights → Dependency graph → Dependabot)
- [ ] Verify weekly PRs open as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)